### PR TITLE
Several changes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -43,7 +43,7 @@ Linux package managers are able to install Vim directly, eg...
 
 
    ```bash
-   pkg install termux-api
+   pkg install vim
    ```
 
 > Note; installing without python support, eg. `pkg install vim`, _should_ also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Changelog
 
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
-
-
-- Detect when device state disallows access to `termux-clipboard-get` and
-  `termux-clipboard-set` commands
 
    > Possibly related discussions and information
    >
@@ -21,12 +15,26 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
    > - [Redit -- Check if display is on or off](https://www.reddit.com/r/termux/comments/11e2s3j/check_if_display_is_on_or_off/)
    > - [Redit -- How to wake/turn on the screen via Termux?](https://www.reddit.com/r/termux/comments/kysbsk/how_to_waketurn_on_the_screen_via_termux/)
 
-
 ## [0.0.1] - 2024-03-26
-
 
 ### Added
 
-
 - Start maintaining versions and a changelog.
+
+## [0.0.2] - 2026-03-06
+
+### Added
+
+- Add fast finish when Termux clipboard commands are not available.
+- Add l mapping to get Android clipboard into unnamed reg.
+
+### Changed
+
+- Change yank to use system to be more robust.
+- Change p and P to not be remapped by default to be compatible with [vim-yankstack](https://github.com/maxbrunsfeld/vim-yankstack).
+- Fix <https://github.com/vim-utilities/termux-clipboard/issues/1>.
+
+### Removed
+
+- Remove fallback for + since Termux build typically doesn't have clipboard support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,20 +21,20 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Start maintaining versions and a changelog.
 
-## [0.0.2] - 2026-03-06
+## [0.0.2] - 2026-03-08
 
 ### Added
 
 - Add fast finish when Termux clipboard commands are not available.
-- Add l mapping to get Android clipboard into unnamed reg.
+- Add `t` mapping to get Android clipboard into unnamed reg.
 
 ### Changed
 
-- Change yank to use system to be more robust.
-- Change p and P to not be remapped by default to be compatible with [vim-yankstack](https://github.com/maxbrunsfeld/vim-yankstack).
+- Change yanking to use system to be more robust.
+- Change `p` and `P` to not be remapped by default to be compatible with [vim-yankstack](https://github.com/maxbrunsfeld/vim-yankstack).
 - Fix <https://github.com/vim-utilities/termux-clipboard/issues/1>.
 
 ### Removed
 
-- Remove fallback for + since Termux build typically doesn't have clipboard support.
+- Remove fallback since Termux build typically doesn't have clipboard support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - Start maintaining versions and a changelog.
 
-## [0.0.2] - 2026-03-08
+## [0.0.2] - 2026-03-11
 
 ### Added
 
 - Add fast finish when Termux clipboard commands are not available.
-- Add `t` mapping to get Android clipboard into unnamed reg.
+- Add `Z` mapping to get Android clipboard into unnamed reg.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Just use `"+y`, `"+p`, `<C-R>+` as you always do. Specifically, here's what's su
 - Any yank command that starts with `"+` (e.g. `"+yy` or `"+yiw`) in insert and visual modes.
 - Pasting in normal and visual modes with `"+p` or `"+P`.
 - Pasting in insert mode with `<C-R>+`, `<C-R><C-R>+`, `<C-R><C-O>+`, or `<C-R><C-P>+`.
-- Press `t` to load Android clipboard content into unnamed register to be used by `p`, `P`, `""p`, `""P`.
+- Press `t` to load Android clipboard content into unnamed reg to be used by `p`, `P`, `""p`, `""P`.
 
 If you need more functionality, consider checking out [vim-fakeclip](https://github.com/kana/vim-fakeclip).
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Just use `"+y`, `"+p`, `<C-R>+` as you always do. Specifically, here's what's su
 - Any yank command that starts with `"+` (e.g. `"+yy` or `"+yiw`) in insert and visual modes.
 - Pasting in normal and visual modes with `"+p` or `"+P`.
 - Pasting in insert mode with `<C-R>+`, `<C-R><C-R>+`, `<C-R><C-O>+`, or `<C-R><C-P>+`.
-- Press `t` to load Android clipboard content into unnamed reg to be used by `p`, `P`, `""p`, `""P`.
+- Press `Z` to load Android clipboard content into unnamed reg to be used by `p`, `P`, `""p`, `""P`.
 
 If you need more functionality, consider checking out [vim-fakeclip](https://github.com/kana/vim-fakeclip).
 

--- a/README.md
+++ b/README.md
@@ -34,29 +34,40 @@ Integrate Vim '+' register with the Android system clipboard via Termux APIs
   "&#x1F3D7; Prerequisites and/or dependencies that this project needs to function properly"
 
 
-This repository requires the [Vim][vim_home] text editor to be installed the
-source code is available on [GitHub -- `vim/vim`][vim__github], and most GNU
-Linux package managers are able to install Vim directly, eg...
-
+This repository is for the [Vim][vim_home] text editor, whose source code is available on [GitHub -- `vim/vim`][vim__github], and most GNU
+Linux package managers are able to install Vim directly, e.g.
 
 - Termux
-
-
    ```bash
    pkg install vim
+   ```
+- Debian/Ubuntu
+   ```bash
+   apt update
+   apt install vim
    ```
 
 > Note; installing without python support, eg. `pkg install vim`, _should_ also
 > function fine instead for this plugin
 
-Additionally the Termux API CLI must be installed within via;
+Additionally the Termux API CLI must be installed in Termux:
+```bash
+pkg install termux-api
+```
+and the corresponding [Termux:API](https://wiki.termux.com/wiki/Termux:API) app must be installed as well.
 
-   ```bash
-   pkg install termux-api
-   ```
+If using in proot-distro, termux-api binaries must be exposed to it, which can be done by not using `--isolated` or using `--isolated --bind /apex --bind /data/dalvik-cache --bind /system --bind /linkerconfig --bind /vendor --bind /data/data/com.termux/files/usr` when logging in.
 
-... As well as the corresponding [API](https://wiki.termux.com/wiki/Termux:API)
-
+Moreover, `uuidgen` is used in yanking (copying), which can be installed via
+- Termux
+    ```bash
+    pkg install uuid-utils
+    ```
+- Debian/Ubuntu
+    ```bash
+    apt update
+    apt install uuid-runtime
+    ```
 
 ______
 
@@ -115,12 +126,12 @@ ______
 
 
 
-Just use `"+y`, `"+p`, `<C-R>+`, and friends as you always do. Specifically, here's what's supported:
+Just use `"+y`, `"+p`, `<C-R>+` as you always do. Specifically, here's what's supported:
 
 - Any yank command that starts with `"+` (e.g. `"+yy` or `"+yiw`) in insert and visual modes.
 - Pasting in normal and visual modes with `"+p` or `"+P`.
 - Pasting in insert mode with `<C-R>+`, `<C-R><C-R>+`, `<C-R><C-O>+`, or `<C-R><C-P>+`.
-- Yanking and pasting (`p` and `P` in normal and visual modes) with `clipboard=unnamedplus`.
+- Press `t` to load Android clipboard content into unnamed register to be used by `p`, `P`, `""p`, `""P`.
 
 If you need more functionality, consider checking out [vim-fakeclip](https://github.com/kana/vim-fakeclip).
 

--- a/plugin/termux-clipboard.vim
+++ b/plugin/termux-clipboard.vim
@@ -107,10 +107,10 @@ endfunction
 
 nnoremap <expr> <silent> "+p <SID>put('p')
 nnoremap <expr> <silent> "+P <SID>put('P')
-nnoremap <expr> <silent> l <SID>clipboard_to_unnamed()
+nnoremap <expr> <silent> t <SID>clipboard_to_unnamed()
 vnoremap <expr> <silent> "+p <SID>put('p')
 vnoremap <expr> <silent> "+P <SID>put('P')
-vnoremap <expr> <silent> l <SID>clipboard_to_unnamed()
+vnoremap <expr> <silent> t <SID>clipboard_to_unnamed()
 
 if g:termux_clipboard_remap
     nnoremap <expr> <silent> p <SID>put('p')

--- a/plugin/termux-clipboard.vim
+++ b/plugin/termux-clipboard.vim
@@ -84,7 +84,10 @@ endif
 " See: {docs} :help job_start
 function! s:Termux_Yank() abort
     if v:event['regname'] ==# ''
-        call system('sh -c "echo '.shellescape(getreg(v:event['regname'])).' | termux-clipboard-set &"')
+        let l:text = getreg(v:event['regname'])
+        let l:uuid = substitute(system('uuidgen'), '\n', '', '')
+        let l:cmd = "cat << '" . l:uuid . "'" . ' | termux-clipboard-set &' . "\n" . l:text . "\n" . l:uuid
+        call system('sh', l:cmd)
     endif
 endfunction
 

--- a/plugin/termux-clipboard.vim
+++ b/plugin/termux-clipboard.vim
@@ -1,6 +1,6 @@
 #!/usr/bin/env vim
 " termux-clipboard.vim - Yank/Put to/from Android clipboard via Vim
-" Version: 0.0.1
+" Version: 0.0.2
 " Maintainer: S0AndS0
 " License: AGPL-3.0
 "
@@ -14,12 +14,17 @@
 
 
 ""
-" Fast finish if already loaded or Vim version is bellow target
-if exists('g:termux_clipboard__loaded') || v:version < 700
+" Fast finish if already loaded, Vim version bellow target, or Termux clipboard commands not available
+if exists('g:termux_clipboard__loaded') || v:version < 700 || executable('termux-clipboard-set') == 0 || executable('termux-clipboard-get') == 0
 	finish
 endif
 let g:termux_clipboard__loaded = 1
 
+""
+" Remap p and P only when user set g:termux_clipboard_remap to 1
+if !exists('g:termux_clipboard_remap')
+    let g:termux_clipboard_remap = 0
+endif
 
 ""
 " Merged dictionary without mutation
@@ -71,22 +76,16 @@ else
 	let g:termux_clipboard = s:defaults
 endif
 
-
 ""
 " ... Registration of mode mapping should be added here...
 
 ""
 " See: {docs} :help TextYankPost
 " See: {docs} :help job_start
-function! s:Termux_Yank()
-	if v:event['regname'] == '+' || v:event['regname'] == ''
-				silent call job_start(['termux-clipboard-set'] + [getreg(v:event['regname'])], {
-					\ 	"in_io": "null",
-					\ 	"out_io": "null",
-					\ 	"err_io": "null",
-					\ 	"stoponexit": "",
-					\ })
-	endif
+function! s:Termux_Yank() abort
+    if v:event['regname'] ==# ''
+        call system('sh -c "echo '.shellescape(getreg(v:event['regname'])).' | termux-clipboard-set &"')
+    endif
 endfunction
 
 augroup TermuxYank
@@ -98,36 +97,29 @@ function! s:clipboard_to_unnamed()
 	silent let @"=system('termux-clipboard-get')
 endfunction
 
-function! s:put(p, fallback)
-	if a:fallback
-			return a:p
-	endif
-
-	call s:clipboard_to_unnamed()
-	return '""' . a:p
+function! s:put(p)
+    call s:clipboard_to_unnamed()
+    return '""' . a:p
 endfunction
 
-function! s:ctrl_r(cr)
-	call s:clipboard_to_unnamed()
-	return a:cr . '"'
-endfunction
+nnoremap <expr> <silent> "+p <SID>put('p')
+nnoremap <expr> <silent> "+P <SID>put('P')
+nnoremap <expr> <silent> l <SID>clipboard_to_unnamed()
+vnoremap <expr> <silent> "+p <SID>put('p')
+vnoremap <expr> <silent> "+P <SID>put('P')
+vnoremap <expr> <silent> l <SID>clipboard_to_unnamed()
 
-nnoremap <expr> <silent> "+p <SID>put('p', v:false)
-nnoremap <expr> <silent> "+P <SID>put('P', v:false)
-nnoremap <expr> <silent> p <SID>put('p', has('clipboard') && clipboard !~ 'unnamedplus')
-nnoremap <expr> <silent> P <SID>put('P', has('clipboard') && clipboard !~ 'unnamedplus')
+if g:termux_clipboard_remap
+    nnoremap <expr> <silent> p <SID>put('p')
+    nnoremap <expr> <silent> P <SID>put('P')
+    vnoremap <expr> <silent> p <SID>put('p')
+    vnoremap <expr> <silent> P <SID>put('P')
+endif
 
-
-vnoremap <expr> <silent> "+p <SID>put('p', v:false)
-vnoremap <expr> <silent> "+P <SID>put('P', v:false)
-vnoremap <expr> <silent> p <SID>put('p', has('clipboard') && &clipboard !~ 'unnamedplus')
-vnoremap <expr> <silent> P <SID>put('P', has('clipboard') && &clipboard !~ 'unnamedplus')
-
-
-inoremap <expr> <silent> <C-R>+ <SID>ctrl_r("\<C-R>")
-inoremap <expr> <silent> <C-R><C-R>+ <SID>ctrl_r("\<C-R>\<C-R>")
-inoremap <expr> <silent> <C-R><C-O>+ <SID>ctrl_r("\<C-R>\<C-O>")
-inoremap <expr> <silent> <C-R><C-P>+ <SID>ctrl_r("\<C-R>\<C-P>")
+inoremap <expr> <silent> <C-R>+ <SID>put("\<C-R>")
+inoremap <expr> <silent> <C-R><C-R>+ <SID>put("\<C-R>\<C-R>")
+inoremap <expr> <silent> <C-R><C-O>+ <SID>put("\<C-R>\<C-O>")
+inoremap <expr> <silent> <C-R><C-P>+ <SID>put("\<C-R>\<C-P>")
 
 
 " vim:foldmethod=marker:foldlevel=0

--- a/plugin/termux-clipboard.vim
+++ b/plugin/termux-clipboard.vim
@@ -84,7 +84,7 @@ endif
 " See: {docs} :help job_start
 function! s:Termux_Yank() abort
     if v:event['regname'] ==# ''
-        let l:text = getreg(v:event['regname'])
+        let l:text = substitute(getreg(v:event['regname']), '\n$', '', '')
         let l:uuid = substitute(system('uuidgen'), '\n', '', '')
         let l:cmd = "cat << '" . l:uuid . "'" . ' | termux-clipboard-set &' . "\n" . l:text . "\n" . l:uuid
         call system('sh', l:cmd)
@@ -107,10 +107,10 @@ endfunction
 
 nnoremap <expr> <silent> "+p <SID>put('p')
 nnoremap <expr> <silent> "+P <SID>put('P')
-nnoremap <expr> <silent> t <SID>clipboard_to_unnamed()
+nnoremap <expr> <silent> Z <SID>clipboard_to_unnamed()
 vnoremap <expr> <silent> "+p <SID>put('p')
 vnoremap <expr> <silent> "+P <SID>put('P')
-vnoremap <expr> <silent> t <SID>clipboard_to_unnamed()
+vnoremap <expr> <silent> Z <SID>clipboard_to_unnamed()
 
 if g:termux_clipboard_remap
     nnoremap <expr> <silent> p <SID>put('p')


### PR DESCRIPTION
### Added

- Add fast finish when Termux clipboard commands are not available.
- Add `Z` mapping to get Android clipboard into unnamed reg.

### Changed

- Change yanking to use system to be more robust.
- Change `p` and `P` to not be remapped by default to be compatible with [vim-yankstack](https://github.com/maxbrunsfeld/vim-yankstack).
- Fix <https://github.com/vim-utilities/termux-clipboard/issues/1>.

### Removed

- Remove fallback since Termux build typically doesn't have clipboard support.


